### PR TITLE
ユーザーモデルの名前をSlackからUserに変更

### DIFF
--- a/app/controllers/summaries_controller.rb
+++ b/app/controllers/summaries_controller.rb
@@ -65,6 +65,6 @@ class SummariesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def summary_params
-      params.require(:summary).permit(:title, :slack_id)
+      params.require(:summary).permit(:title, :user_id)
     end
 end

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -1,3 +1,3 @@
 class Summary < ApplicationRecord
-  belongs_to :slack
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class Slack < ApplicationRecord
+class User < ApplicationRecord
   has_many :summary
   has_secure_password
 end

--- a/app/views/summaries/_form.html.erb
+++ b/app/views/summaries/_form.html.erb
@@ -17,8 +17,8 @@
   </div>
 
   <div class="field">
-    <%= form.label :slack_id %>
-    <%= form.text_field :slack_id, id: :summary_slack_id %>
+    <%= form.label :user_id %>
+    <%= form.text_field :user_id, id: :summary_user_id %>
   </div>
 
   <div class="actions">

--- a/app/views/summaries/_summary.json.jbuilder
+++ b/app/views/summaries/_summary.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! summary, :id, :title, :slack_id, :created_at, :updated_at
+json.extract! summary, :id, :title, :user_id, :created_at, :updated_at
 json.url summary_url(summary, format: :json)

--- a/app/views/summaries/index.html.erb
+++ b/app/views/summaries/index.html.erb
@@ -6,7 +6,7 @@
   <thead>
     <tr>
       <th>Title</th>
-      <th>Slack</th>
+      <th>User</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -15,7 +15,7 @@
     <% @summaries.each do |summary| %>
       <tr>
         <td><%= summary.title %></td>
-        <td><%= summary.slack %></td>
+        <td><%= summary.user %></td>
         <td><%= link_to 'Show', summary %></td>
         <td><%= link_to 'Destroy', summary, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/summaries/show.html.erb
+++ b/app/views/summaries/show.html.erb
@@ -6,8 +6,8 @@
 </p>
 
 <p>
-  <strong>Slack:</strong>
-  <%= @summary.slack %>
+  <strong>User:</strong>
+  <%= @summary.user %>
 </p>
 
 <%= link_to 'Back', summaries_path %>

--- a/db/fixtures/development/01_users.rb
+++ b/db/fixtures/development/01_users.rb
@@ -1,7 +1,7 @@
-Slack.destroy_all
+User.destroy_all
 
 10.times do |i|
-  Slack.seed(:id) do |s|
+  User.seed(:id) do |s|
     s.id              = i+1
     s.first_name      = "first_name_#{i+1}"
     s.last_name       = "last_name_#{i+1}"

--- a/db/migrate/20170512033820_remove_slack_from_summary.rb
+++ b/db/migrate/20170512033820_remove_slack_from_summary.rb
@@ -1,0 +1,6 @@
+class RemoveSlackFromSummary < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key :summaries, :slacks
+    remove_reference :summaries, :slack, index: true
+  end
+end

--- a/db/migrate/20170512034820_rename_slacks_to_users.rb
+++ b/db/migrate/20170512034820_rename_slacks_to_users.rb
@@ -1,0 +1,5 @@
+class RenameSlacksToUsers < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :slacks, :users
+  end
+end

--- a/db/migrate/20170512050808_rename_slack_to_summaries.rb
+++ b/db/migrate/20170512050808_rename_slack_to_summaries.rb
@@ -1,6 +1,0 @@
-class RenameSlackToSummaries < ActiveRecord::Migration[5.1]
-  def change
-    remove_reference :summaries, :slack
-    add_reference :summaries, :user
-  end
-end

--- a/db/migrate/20170512050808_rename_slack_to_summaries.rb
+++ b/db/migrate/20170512050808_rename_slack_to_summaries.rb
@@ -1,0 +1,6 @@
+class RenameSlackToSummaries < ActiveRecord::Migration[5.1]
+  def change
+    remove_reference :summaries, :slack
+    add_reference :summaries, :user
+  end
+end

--- a/db/migrate/20170512060552_add_user_from_summary.rb
+++ b/db/migrate/20170512060552_add_user_from_summary.rb
@@ -1,0 +1,5 @@
+class AddUserFromSummary < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :summaries, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512050808) do
+ActiveRecord::Schema.define(version: 20170512060552) do
 
   create_table "summaries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title", null: false
@@ -30,4 +30,5 @@ ActiveRecord::Schema.define(version: 20170512050808) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "summaries", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170510095511) do
+ActiveRecord::Schema.define(version: 20170512050808) do
 
-  create_table "slacks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "summaries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_summaries_on_user_id"
+  end
+
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
@@ -22,13 +30,4 @@ ActiveRecord::Schema.define(version: 20170510095511) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "summaries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "title", null: false
-    t.bigint "slack_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["slack_id"], name: "index_summaries_on_slack_id"
-  end
-
-  add_foreign_key "summaries", "slacks"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :slack_user, class: Slack do
+  factory :user do
     first_name      'first_name'
     last_name       'last_name'
     email           'name_1@example.com'

--- a/spec/features/summaries/new_summary_page_spec.rb
+++ b/spec/features/summaries/new_summary_page_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe 'New Summaryページ' do
+
+  before do
+    visit summaries_path
+    click_link 'New Summary'
+  end
+
+  context '正常系(ボタンクリックなどによる外観の変化)' do
+
+    let!(:user){ create(:user) }
+
+    before do
+      fill_in 'Title', with: 'Test Title'
+      fill_in 'User', with: "#{user.id}"
+      click_button 'Create Summary'
+    end
+
+
+    specify '新しいSummaryを作成できたらSummariesページに遷移する' do
+      expect(current_path).to eq(summary_path(Summary.last.id))
+    end
+
+    specify '遷移先にメッセージが表示される' do
+      expect(page).to have_css('p', text: 'Summary was successfully created.')
+    end
+
+    specify '遷移先のタイトルが作成したものが表示されている' do
+      expect(page).to have_css('p', text: 'Test Title')
+    end
+
+    specify '遷移先にBackリンクがある' do
+      expect(page).to have_link(text: 'Back', href:summaries_path)
+    end
+
+  end
+
+  context '異常系(ボタンクリックなどによる外観の変化)' do
+
+    context '存在しないslack.idを打った場合' do
+
+      let!(:user){ create(:user) }
+
+      before do
+        fill_in 'Title', with: 'Test Title'
+        fill_in 'User', with: '-1'
+        click_button 'Create Summary'
+      end
+
+      specify 'エラーメッセージが表示される(タイトル)' do
+        expect(page).to have_css('h2', text: '1 error prohibited this summary from being saved:')
+      end
+
+      specify 'エラーメッセージが表示される(内容)' do
+        expect(page).to have_css('li', text:'User must exist')
+      end
+
+      specify '新しいSummaryを作成できなかったのでSummariesページに遷移しない' do
+        expect(current_path).to eq(summaries_path)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/features/summaries/summaries_page_spec.rb
+++ b/spec/features/summaries/summaries_page_spec.rb
@@ -8,12 +8,12 @@ describe 'Summariesページ', :js => true do
 
   context '正常系(ボタンクリックなどによる外観の変化)' do
 
-    let!(:slack_user){ create(:slack_user) }
+    let!(:user){ create(:user) }
 
     before do
       click_link 'New Summary'
       fill_in 'Title',  with: 'Test Title'
-      fill_in 'Slack',  with: "#{slack_user.id}"
+      fill_in 'User',  with: "#{user.id}"
       click_button 'Create Summary'
       click_link 'Back'
     end
@@ -41,8 +41,8 @@ describe 'Summariesページ', :js => true do
         expect(page).to have_css('p', text: 'Test Title')
       end
 
-      specify 'Slackのパラグラフの表示確認' do
-        expect(page).to have_css('strong', text: 'Slack:')
+      specify 'Userのパラグラフの表示確認' do
+        expect(page).to have_css('strong', text: 'User:')
       end
 
       specify 'Backリンクの表示確認' do
@@ -99,67 +99,4 @@ describe 'Summariesページ', :js => true do
 
   end
 
-end
-
-describe 'New Summaryページ' do
-
-  before do
-    visit summaries_path
-    click_link 'New Summary'
-  end
-
-  context '正常系(ボタンクリックなどによる外観の変化)' do
-
-    let!(:slack_user){ create(:slack_user) }
-
-    before do
-      fill_in 'Title', with: 'Test Title'
-      fill_in 'Slack', with: "#{slack_user.id}"
-      click_button 'Create Summary'
-    end
-
-
-    specify '新しいSummaryを作成できたらSummariesページに遷移する' do
-      expect(current_path).to eq(summary_path(Summary.last.id))
-    end
-
-    specify '遷移先にメッセージが表示される' do
-      expect(page).to have_css('p', text: 'Summary was successfully created.')
-    end
-
-    specify '遷移先のタイトルが作成したものが表示されている' do
-      expect(page).to have_css('p', text: 'Test Title')
-    end
-
-    specify '遷移先にBackリンクがある' do
-      expect(page).to have_link(text: 'Back', href:summaries_path)
-    end
-
-  end
-
-  context '異常系(ボタンクリックなどによる外観の変化)' do
-
-    context '存在しないslack.idを打った場合' do
-
-      let!(:slack_user){ create(:slack_user) }
-
-      before do
-        fill_in 'Title', with: 'Test Title'
-        fill_in 'Slack', with: '-1'
-        click_button 'Create Summary'
-      end
-
-      specify 'エラーメッセージが表示される(タイトル)' do
-        expect(page).to have_css('h2', text: '1 error prohibited this summary from being saved:')
-      end
-
-      specify 'エラーメッセージが表示される(内容)' do
-        expect(page).to have_css('li', text:'Slack must exist')
-      end
-
-      specify '新しいSummaryを作成できなかったのでSummariesページに遷移しない' do
-        expect(current_path).to eq("/summaries")
-      end
-    end
-  end
 end


### PR DESCRIPTION
## ストーリー

なし

## 概要

ユーザーモデルの名前がSlackだったのでUserに変更

## 画面

なし

## 仕様・注意事項

なし

## 見どころ

new file:   .github/ISSUE_TEMPLATE.md
        new file:   .github/PULL_REQUEST_TEMPLATE.md
        modified:   app/controllers/summaries_controller.rb
        modified:   app/models/summary.rb
        renamed:    app/models/slack.rb -> app/models/user.rb
        modified:   app/views/summaries/_form.html.erb
        modified:   app/views/summaries/_summary.json.jbuilder
        modified:   app/views/summaries/index.html.erb
        modified:   app/views/summaries/show.html.erb
        renamed:    db/fixtures/development/01_slacks.rb -> db/fixtures/development/01_users.rb
        renamed:    db/migrate/20170510095221_create_slacks.rb -> db/migrate/20170510095221_create_users.rb
        modified:   db/migrate/20170510095511_create_summaries.rb
        modified:   db/schema.rb
        renamed:    spec/factories/slacks.rb -> spec/factories/users.rb
        modified:   spec/features/summary_spec.rb